### PR TITLE
fix: Add type not to treat rules value as string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
 import fs from 'fs';
 
 import { rules } from './rules/index.js';
@@ -9,7 +10,7 @@ const { name, version } = JSON.parse(
   version: string;
 };
 
-const plugin = {
+const plugin: FlatConfig.Plugin = {
   meta: { name, version },
   configs: {
     get recommended() {
@@ -19,7 +20,7 @@ const plugin = {
   rules,
 };
 
-const recommended = {
+const recommended: FlatConfig.Config = {
   plugins: {
     neverthrow: plugin,
   },


### PR DESCRIPTION
The recommended type is treated as follows.

```
(property) recommended: {
    plugins: {
        neverthrow: any;
    };
    rules: {
        "neverthrow/must-use-result": string;
    };
}
```

The value of rules item shouldn't be string but "error" etc.