### PR TITLE
chore: drop Node.js 18 support, require Node.js >=20

### DIFF
--- a/.changeset/fix-type-portability.md
+++ b/.changeset/fix-type-portability.md
@@ -1,10 +1,11 @@
 ---
-'@bufferings/eslint-plugin-neverthrow': patch
+'@bufferings/eslint-plugin-neverthrow': minor
 ---
 
-Fix type portability issues and align @typescript-eslint versions
+Fix type portability issues and align typescript-eslint versions
 
 - Add explicit type annotations to fix non-portable inferred types
 - Remove deprecated @types/eslint\_\_js stub package
 - Upgrade @typescript-eslint/utils to 8.48.0 to align with other typescript-eslint packages
 - Update peerDependencies to require @typescript-eslint/parser >=8.48.0
+- Drop Node.js 18 support (EOL April 2025), require Node.js >=20.0.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
+    ignore:
+      # Keep @types/node on 20.x to match engines.node minimum version
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       dev-dependencies:
         dependency-type: 'development'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.12",
   "description": "",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "@changesets/cli": "2.29.8",
     "@eslint/js": "9.39.1",
     "@types/eslint": "9.6.1",
-    "@types/node": "22.10.1",
+    "@types/node": "20.19.25",
     "@typescript-eslint/parser": "8.48.0",
     "@typescript-eslint/rule-tester": "8.48.0",
     "eslint": "9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 0.5.2
       '@changesets/cli':
         specifier: 2.29.8
-        version: 2.29.8(@types/node@22.10.1)
+        version: 2.29.8(@types/node@20.19.25)
       '@eslint/js':
         specifier: 9.39.1
         version: 9.39.1
@@ -28,8 +28,8 @@ importers:
         specifier: 9.6.1
         version: 9.6.1
       '@types/node':
-        specifier: 22.10.1
-        version: 22.10.1
+        specifier: 20.19.25
+        version: 20.19.25
       '@typescript-eslint/parser':
         specifier: 8.48.0
         version: 8.48.0(eslint@9.39.1)(typescript@5.9.3)
@@ -74,7 +74,7 @@ importers:
         version: 8.48.0(eslint@9.39.1)(typescript@5.9.3)
       vitest:
         specifier: 2.1.6
-        version: 2.1.6(@types/node@22.10.1)(yaml@2.5.1)
+        version: 2.1.6(@types/node@20.19.25)(yaml@2.5.1)
 
 packages:
 
@@ -513,8 +513,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.10.1':
-    resolution: {integrity: sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==}
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
   '@typescript-eslint/eslint-plugin@8.48.0':
     resolution: {integrity: sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==}
@@ -1541,8 +1541,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -1695,7 +1695,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.8(@types/node@22.10.1)':
+  '@changesets/cli@2.29.8(@types/node@20.19.25)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -1711,7 +1711,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.10.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@20.19.25)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -1952,12 +1952,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.10.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@20.19.25)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.10.1
+      '@types/node': 20.19.25
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -2072,9 +2072,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.10.1':
+  '@types/node@20.19.25':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.21.0
 
   '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3)':
     dependencies:
@@ -2189,13 +2189,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.6(vite@6.4.1(@types/node@22.10.1)(yaml@2.5.1))':
+  '@vitest/mocker@2.1.6(vite@6.4.1(@types/node@20.19.25)(yaml@2.5.1))':
     dependencies:
       '@vitest/spy': 2.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.10.1)(yaml@2.5.1)
+      vite: 6.4.1(@types/node@20.19.25)(yaml@2.5.1)
 
   '@vitest/pretty-format@2.1.6':
     dependencies:
@@ -3095,7 +3095,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.21.0: {}
 
   universalify@0.1.2: {}
 
@@ -3103,13 +3103,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@2.1.6(@types/node@22.10.1)(yaml@2.5.1):
+  vite-node@2.1.6(@types/node@20.19.25)(yaml@2.5.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 6.4.1(@types/node@22.10.1)(yaml@2.5.1)
+      vite: 6.4.1(@types/node@20.19.25)(yaml@2.5.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3124,7 +3124,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.10.1)(yaml@2.5.1):
+  vite@6.4.1(@types/node@20.19.25)(yaml@2.5.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3133,14 +3133,14 @@ snapshots:
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.10.1
+      '@types/node': 20.19.25
       fsevents: 2.3.3
       yaml: 2.5.1
 
-  vitest@2.1.6(@types/node@22.10.1)(yaml@2.5.1):
+  vitest@2.1.6(@types/node@20.19.25)(yaml@2.5.1):
     dependencies:
       '@vitest/expect': 2.1.6
-      '@vitest/mocker': 2.1.6(vite@6.4.1(@types/node@22.10.1)(yaml@2.5.1))
+      '@vitest/mocker': 2.1.6(vite@6.4.1(@types/node@20.19.25)(yaml@2.5.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.6
       '@vitest/snapshot': 2.1.6
@@ -3156,11 +3156,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 6.4.1(@types/node@22.10.1)(yaml@2.5.1)
-      vite-node: 2.1.6(@types/node@22.10.1)(yaml@2.5.1)
+      vite: 6.4.1(@types/node@20.19.25)(yaml@2.5.1)
+      vite-node: 2.1.6(@types/node@20.19.25)(yaml@2.5.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.10.1
+      '@types/node': 20.19.25
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

Drop Node.js 18 support (EOL April 2025) and require Node.js >=20.

## Changes

- Update `engines.node` to `>=20.0.0`
- Update CI matrix to test on Node.js 20, 22, 24
- Downgrade `@types/node` to 20.x to match minimum supported version
- Add dependabot ignore rule to prevent `@types/node` major updates
- Update changeset to minor (breaking change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type portability issues.

* **Chores**
  * Dropped Node.js 18 support; minimum version is now 20.0.0.
  * Aligned TypeScript and ESLint versions.
  * Updated development dependencies and test matrix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->