### PR TITLE
refactor: migrate to ESLint defineConfig API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pnpm install --save-dev @bufferings/eslint-plugin-neverthrow
 
 ### Requirements
 
-- Node.js v18.0.0 or newer versions.
+- Node.js v20.0.0 or newer versions.
 - ESLint v9.0.0 or newer versions.
 
 ## Usage
@@ -31,10 +31,11 @@ Write your config file such as `eslint.config.js`.
 
 ```js
 import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import neverthrowPlugin from '@bufferings/eslint-plugin-neverthrow';
+import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   neverthrowPlugin.configs.recommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,12 @@
 import eslint from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import eslintPlugin from 'eslint-plugin-eslint-plugin';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  {
-    ignores: ['**/dist/', '**/.gitignore'],
-  },
+export default defineConfig(
+  globalIgnores(['**/dist/']),
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   eslintPlugin.configs.recommended,


### PR DESCRIPTION
## Summary

Migrate from deprecated `tseslint.config()` to ESLint's `defineConfig()` API.

## Changes

- Replace deprecated `tseslint.config()` with `defineConfig()` from `eslint/config`
- Use `globalIgnores()` for ignore patterns
- Update README with new Node.js v20 requirement and updated config example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js minimum version requirement from v18 to v20.
  * Updated import examples in setup documentation.

* **Chores**
  * Reorganized ESLint configuration with improved structure and formatting rules enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->