### PR TITLE
fix: update npm to fix OIDC publishing issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm to fix OIDC issue
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

Fix npm OIDC publishing issue caused by npm 10.9.4 bug.

## Changes

- Add `registry-url` for OIDC authentication
- Update npm to latest version to fix OIDC bug

## Reference

- https://github.com/npm/cli/issues/8730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->