### PR TITLE
fix: improve Result detection

### DIFF
--- a/.changeset/fix-result-detection.md
+++ b/.changeset/fix-result-detection.md
@@ -1,0 +1,9 @@
+---
+'@bufferings/eslint-plugin-neverthrow': patch
+---
+
+Fix Result detection issues
+
+- Fix await expressions to be handled properly in Result detection
+- Add support for isOk/isErr methods as valid Result handling
+- Fix false positive on class property definitions (ClassProperty → PropertyDefinition)

--- a/src/rules/must-use-result.test.ts
+++ b/src/rules/must-use-result.test.ts
@@ -172,6 +172,14 @@ ruleTester.run('must-use-result', rule, {
       }
       `
     ),
+    injectResult(
+      'Class property with Result type should not report error',
+      `
+      class MyClass {
+        result = getResult();
+      }
+      `
+    ),
   ],
   invalid: [
     {

--- a/src/rules/must-use-result.test.ts
+++ b/src/rules/must-use-result.test.ts
@@ -154,6 +154,24 @@ ruleTester.run('must-use-result', rule, {
       res2.unwrapOr(5);
       `
     ),
+    injectResult(
+      'Call isOk or isErr',
+      `
+      const result = getResult()
+      if (result.isOk()) {
+        return ok()
+      }
+      `
+    ),
+    injectResult(
+      'Call isOk or isErr',
+      `
+      const result = getResult()
+      if (!result.isErr()) {
+        return ok()
+      }
+      `
+    ),
   ],
   invalid: [
     {
@@ -233,11 +251,11 @@ ruleTester.run('must-use-result', rule, {
       code: injectResult(
         'Await Promise is not handled properly',
         `
-        const res = await getRes(); // case1
-        const res1 = await getRes(); // case2
+        const res = await getResult();
+        const res1 = await getResult();
         res1.unwrapOr;
         
-        await getRes(); // case3
+        await getResult();
         `
       ),
       errors: [
@@ -245,6 +263,18 @@ ruleTester.run('must-use-result', rule, {
         { messageId: MessageIds.MUST_USE },
         { messageId: MessageIds.MUST_USE },
       ],
+    },
+    {
+      code: injectResult(
+        'Await Promise is not handled properly',
+        `
+        const res = getResult();
+        if (res.isOk) {
+          return ok()
+        }
+        `
+      ),
+      errors: [{ messageId: MessageIds.MUST_USE }],
     },
   ],
 });

--- a/src/rules/must-use-result.test.ts
+++ b/src/rules/must-use-result.test.ts
@@ -145,6 +145,15 @@ ruleTester.run('must-use-result', rule, {
     `// Without definitions
       getNormal()
     `,
+    injectResult(
+      'Await Promise handled properly',
+      `
+      (await getRes()).unwrapOr(5);              // case1
+      const res1 = (await getRes()).unwrapOr(5); // case2
+      const res2 = await getRes();               // case3
+      res2.unwrapOr(5);
+      `
+    ),
   ],
   invalid: [
     {
@@ -216,6 +225,23 @@ ruleTester.run('must-use-result', rule, {
       `
       ),
       errors: [
+        { messageId: MessageIds.MUST_USE },
+        { messageId: MessageIds.MUST_USE },
+      ],
+    },
+    {
+      code: injectResult(
+        'Await Promise is not handled properly',
+        `
+        const res = await getRes(); // case1
+        const res1 = await getRes(); // case2
+        res1.unwrapOr;
+        
+        await getRes(); // case3
+        `
+      ),
+      errors: [
+        { messageId: MessageIds.MUST_USE },
         { messageId: MessageIds.MUST_USE },
         { messageId: MessageIds.MUST_USE },
       ],

--- a/src/rules/must-use-result.test.ts
+++ b/src/rules/must-use-result.test.ts
@@ -274,7 +274,7 @@ ruleTester.run('must-use-result', rule, {
     },
     {
       code: injectResult(
-        'Await Promise is not handled properly',
+        'isOk property access without call',
         `
         const res = getResult();
         if (res.isOk) {

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -72,10 +72,10 @@ function isHandledResult(node: TSESTree.Node): boolean {
     return isHandledResult(node.argument);
   }
 
-  const memberExpresion = node.parent;
-  if (memberExpresion?.type === AST_NODE_TYPES.MemberExpression) {
-    const methodName = findMemberName(memberExpresion);
-    const methodIsCalled = isMemberCalledFn(memberExpresion);
+  const memberExpression = node.parent;
+  if (memberExpression?.type === AST_NODE_TYPES.MemberExpression) {
+    const methodName = findMemberName(memberExpression);
+    const methodIsCalled = isMemberCalledFn(memberExpression);
     if (methodName && handledMethods.includes(methodName) && methodIsCalled) {
       return true;
     }

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -223,7 +223,7 @@ function processSelector(
     return false;
   }
 
-  // make sure not reporting to the same node mutiple times during recursing calls
+  // make sure not reporting to the same node multiple times during recursive calls
   if (!isReferenceNode) {
     context.report({
       node: reportAs,

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -163,7 +163,7 @@ const ignoreParents = [
 ];
 
 /**
- * @returns A boolean indicates if the node is not handled.
+ * @returns A boolean indicating whether the node is not handled.
  */
 function processSelector(
   context: TSESLint.RuleContext<MessageIds, []>,

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -15,10 +14,10 @@ function matchAny(nodeTypes: string[]) {
   return `:matches(${nodeTypes.join(', ')})`;
 }
 const resultSelector = matchAny([
-  // 'Identifier',
-  'CallExpression',
-  'NewExpression',
-  'AwaitExpression',
+  // AST_NODE_TYPES.Identifier,
+  AST_NODE_TYPES.CallExpression,
+  AST_NODE_TYPES.NewExpression,
+  AST_NODE_TYPES.AwaitExpression,
 ]);
 
 const resultProperties = [
@@ -69,7 +68,7 @@ function isMemberCalledFn(node?: TSESTree.MemberExpression): boolean {
 
 function isHandledResult(node: TSESTree.Node): boolean {
   // For AwaitExpression, check if the awaited result is handled
-  if (node.type === 'AwaitExpression') {
+  if (node.type === AST_NODE_TYPES.AwaitExpression) {
     return isHandledResult(node.argument);
   }
 
@@ -89,14 +88,14 @@ function isHandledResult(node: TSESTree.Node): boolean {
 }
 
 const isCheckedResult = (node: TSESTree.Node): boolean => {
-  if (node.type === 'Identifier') {
-    if (node.parent?.type === 'MemberExpression') {
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    if (node.parent?.type === AST_NODE_TYPES.MemberExpression) {
       const propertyName =
-        node.parent.property.type === 'Identifier'
+        node.parent.property.type === AST_NODE_TYPES.Identifier
           ? node.parent.property.name
           : null;
       const parentIsCalledExpression =
-        node.parent.parent?.type === 'CallExpression';
+        node.parent.parent?.type === AST_NODE_TYPES.CallExpression;
       return (
         !!propertyName &&
         checkedMethods.includes(propertyName) &&
@@ -107,7 +106,7 @@ const isCheckedResult = (node: TSESTree.Node): boolean => {
   return false;
 };
 
-const endTransverse = ['BlockStatement', 'Program'];
+const endTransverse = [AST_NODE_TYPES.BlockStatement, AST_NODE_TYPES.Program];
 function getAssignation(
   checker: TypeChecker,
   parserServices: ParserServices,
@@ -143,7 +142,7 @@ function isReturned(
   if (node.type === AST_NODE_TYPES.Program) {
     return false;
   }
-  if (node.type === 'AwaitExpression') {
+  if (node.type === AST_NODE_TYPES.AwaitExpression) {
     // For AwaitExpression, check if the parent is returned
     if (!node.parent) {
       return false;
@@ -157,10 +156,10 @@ function isReturned(
 }
 
 const ignoreParents = [
-  'ClassDeclaration',
-  'FunctionDeclaration',
-  'MethodDefinition',
-  'ClassProperty',
+  AST_NODE_TYPES.ClassDeclaration,
+  AST_NODE_TYPES.FunctionDeclaration,
+  AST_NODE_TYPES.MethodDefinition,
+  AST_NODE_TYPES.PropertyDefinition,
 ];
 
 /**
@@ -182,7 +181,7 @@ function processSelector(
   }
 
   // For AwaitExpression, check if the argument is result-like
-  if (node.type === 'AwaitExpression') {
+  if (node.type === AST_NODE_TYPES.AwaitExpression) {
     if (!isResultLike(checker, parserServices, node.argument)) {
       return false;
     }
@@ -195,8 +194,8 @@ function processSelector(
 
   // Skip CallExpression nodes that are inside AwaitExpression to avoid duplicate reporting
   if (
-    node.type === 'CallExpression' &&
-    node.parent?.type === 'AwaitExpression'
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.parent?.type === AST_NODE_TYPES.AwaitExpression
   ) {
     return false;
   }

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -17,6 +17,7 @@ const resultSelector = matchAny([
   // 'Identifier',
   'CallExpression',
   'NewExpression',
+  'AwaitExpression',
 ]);
 
 const resultProperties = [
@@ -133,12 +134,16 @@ const ignoreParents = [
   'ClassProperty',
 ];
 
+/**
+ * @returns A boolean indicates if the node is not handled.
+ */
 function processSelector(
   context: TSESLint.RuleContext<MessageIds, []>,
   checker: TypeChecker,
   parserServices: ParserServices,
   node: TSESTree.Node,
-  reportAs = node
+  reportAs = node,
+  isReferenceNode = false
 ): boolean {
   if (node.parent?.type.startsWith('TS')) {
     return false;
@@ -158,31 +163,25 @@ function processSelector(
     return false;
   }
 
-  const assignedTo = getAssignation(checker, parserServices, node);
-  const currentScope = context.sourceCode.getScope(node);
-
-  // Check if is assigned
-  if (assignedTo) {
-    const variable = currentScope.set.get(assignedTo.name);
-    const references =
-      variable?.references.filter((ref) => ref.identifier !== assignedTo) ?? [];
-    if (references.length > 0) {
-      return references.some((ref) =>
-        processSelector(
-          context,
-          checker,
-          parserServices,
-          ref.identifier,
-          reportAs
-        )
-      );
-    }
+  const anyHandled = handleAssignation(
+    context,
+    checker,
+    parserServices,
+    node,
+    reportAs
+  );
+  if (anyHandled) {
+    return false;
   }
 
-  context.report({
-    node: reportAs,
-    messageId: MessageIds.MUST_USE,
-  });
+  // make sure not reporting to the same node mutiple times during recursing calls
+  if (!isReferenceNode) {
+    context.report({
+      node: reportAs,
+      messageId: MessageIds.MUST_USE,
+    });
+  }
+
   return true;
 }
 
@@ -220,3 +219,42 @@ export const rule = createRule({
   name: 'must-use-result',
   defaultOptions: [],
 });
+
+function handleAssignation(
+  context: TSESLint.RuleContext<MessageIds, []>,
+  checker: TypeChecker,
+  parserServices: ParserServices,
+  node: TSESTree.Node,
+  reportAs: TSESTree.Node = node
+): boolean {
+  const assignedTo = getAssignation(checker, parserServices, node);
+  const currentScope = context.sourceCode.getScope(node);
+
+  // Check if is assigned to variables
+  if (assignedTo) {
+    const variable = currentScope.set.get(assignedTo.name);
+    const references =
+      variable?.references.filter((ref) => ref.identifier !== assignedTo) ?? [];
+
+    /**
+     * Try to mark the first assigned variable to be reported, if not, keep
+     * the original one.
+     */
+    reportAs = variable?.references[0].identifier ?? reportAs;
+
+    // check if any reference is handled by recursive calling
+    return references.some(
+      (ref) =>
+        !processSelector(
+          context,
+          checker,
+          parserServices,
+          ref.identifier,
+          reportAs,
+          true
+        )
+    );
+  }
+
+  return false;
+}

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -30,13 +31,9 @@ const resultProperties = [
 ];
 
 const handledMethods = ['match', 'unwrapOr', '_unsafeUnwrap'];
+const checkedMethods = ['isOk', 'isErr'];
 
-// evaluates inside the expression if it is result
-// if result check that it is handled in the expression
-// if it is unhandled checks if it is assigned or used as an argument to a function
-// if it was assigned unhandled checks the entire variable block for handles
-//   otherwise it was handled properly
-
+// evaluate if the node is result-like
 function isResultLike(
   checker: TypeChecker,
   parserServices: ParserServices,
@@ -71,6 +68,11 @@ function isMemberCalledFn(node?: TSESTree.MemberExpression): boolean {
 }
 
 function isHandledResult(node: TSESTree.Node): boolean {
+  // For AwaitExpression, check if the awaited result is handled
+  if (node.type === 'AwaitExpression') {
+    return isHandledResult(node.argument);
+  }
+
   const memberExpresion = node.parent;
   if (memberExpresion?.type === AST_NODE_TYPES.MemberExpression) {
     const methodName = findMemberName(memberExpresion);
@@ -85,6 +87,26 @@ function isHandledResult(node: TSESTree.Node): boolean {
   }
   return false;
 }
+
+const isCheckedResult = (node: TSESTree.Node): boolean => {
+  if (node.type === 'Identifier') {
+    if (node.parent?.type === 'MemberExpression') {
+      const propertyName =
+        node.parent.property.type === 'Identifier'
+          ? node.parent.property.name
+          : null;
+      const parentIsCalledExpression =
+        node.parent.parent?.type === 'CallExpression';
+      return (
+        !!propertyName &&
+        checkedMethods.includes(propertyName) &&
+        parentIsCalledExpression
+      );
+    }
+  }
+  return false;
+};
+
 const endTransverse = ['BlockStatement', 'Program'];
 function getAssignation(
   checker: TypeChecker,
@@ -121,6 +143,13 @@ function isReturned(
   if (node.type === AST_NODE_TYPES.Program) {
     return false;
   }
+  if (node.type === 'AwaitExpression') {
+    // For AwaitExpression, check if the parent is returned
+    if (!node.parent) {
+      return false;
+    }
+    return isReturned(checker, parserServices, node.parent);
+  }
   if (!node.parent) {
     return false;
   }
@@ -151,14 +180,35 @@ function processSelector(
   if (node.parent && ignoreParents.includes(node.parent.type)) {
     return false;
   }
-  if (!isResultLike(checker, parserServices, node)) {
+
+  // For AwaitExpression, check if the argument is result-like
+  if (node.type === 'AwaitExpression') {
+    if (!isResultLike(checker, parserServices, node.argument)) {
+      return false;
+    }
+  } else {
+    // For other node types, check if the node itself is result-like
+    if (!isResultLike(checker, parserServices, node)) {
+      return false;
+    }
+  }
+
+  // Skip CallExpression nodes that are inside AwaitExpression to avoid duplicate reporting
+  if (
+    node.type === 'CallExpression' &&
+    node.parent?.type === 'AwaitExpression'
+  ) {
     return false;
   }
 
   if (isHandledResult(node)) {
     return false;
   }
-  // return getResult()
+
+  if (isCheckedResult(node)) {
+    return false;
+  }
+
   if (isReturned(checker, parserServices, node)) {
     return false;
   }


### PR DESCRIPTION
## Summary

Improve Result detection with fixes ported from upstream and additional fixes.

## Changes

- Fix await expressions to be handled properly in Result detection
- Add support for `isOk`/`isErr` methods as valid Result handling  
- Fix false positive on class property definitions (`ClassProperty` → `PropertyDefinition`)
- Use `AST_NODE_TYPES` constants instead of string literals for type safety

## Ported from upstream

- mdbetancourt/eslint-plugin-neverthrow#17 (cf08478)
- mdbetancourt/eslint-plugin-neverthrow#22 (b7df2e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of awaited Results and reduced duplicate reports
  * Fixed false positives for class properties typed as Result
  * Better handling of Result values propagated through assignments

* **New Features**
  * Recognizes isOk and isErr as valid Result-checking patterns

* **Tests**
  * Added tests covering awaited Results, isOk/isErr checks, and mixed control-flow cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->