### PR TITLE
fix: detect await Promise<Result> correctly in must-use-result rule

### DIFF
--- a/.changeset/fix-await-promise-result.md
+++ b/.changeset/fix-await-promise-result.md
@@ -1,0 +1,5 @@
+---
+'@bufferings/eslint-plugin-neverthrow': patch
+---
+
+fix: detect `await Promise<Result>` correctly in `must-use-result` rule

--- a/src/rules/must-use-result.test.ts
+++ b/src/rules/must-use-result.test.ts
@@ -77,6 +77,7 @@ declare class Err<T, E> implements IResult<T, E> {
 }
 
 declare function getResult(): Result<string, Error>
+declare function asyncGetResult(): Promise<Result<string, Error>>
 declare function getNormal(): number
 const obj: { get: () => Result<string, Error> }
 
@@ -178,6 +179,15 @@ ruleTester.run('must-use-result', rule, {
       class MyClass {
         result = getResult();
       }
+      `
+    ),
+    injectResult(
+      'Await Promise<Result> handled properly',
+      `
+      (await asyncGetResult()).unwrapOr(5);
+      const res1 = (await asyncGetResult()).unwrapOr(5);
+      const res2 = await asyncGetResult();
+      res2.unwrapOr(5);
       `
     ),
   ],
@@ -283,6 +293,23 @@ ruleTester.run('must-use-result', rule, {
         `
       ),
       errors: [{ messageId: MessageIds.MUST_USE }],
+    },
+    {
+      code: injectResult(
+        'Await Promise<Result> is not handled properly',
+        `
+        const res = await asyncGetResult();
+        const res1 = await asyncGetResult();
+        res1.unwrapOr;
+        
+        await asyncGetResult();
+        `
+      ),
+      errors: [
+        { messageId: MessageIds.MUST_USE },
+        { messageId: MessageIds.MUST_USE },
+        { messageId: MessageIds.MUST_USE },
+      ],
     },
   ],
 });

--- a/src/rules/must-use-result.ts
+++ b/src/rules/must-use-result.ts
@@ -67,11 +67,6 @@ function isMemberCalledFn(node?: TSESTree.MemberExpression): boolean {
 }
 
 function isHandledResult(node: TSESTree.Node): boolean {
-  // For AwaitExpression, check if the awaited result is handled
-  if (node.type === AST_NODE_TYPES.AwaitExpression) {
-    return isHandledResult(node.argument);
-  }
-
   const memberExpression = node.parent;
   if (memberExpression?.type === AST_NODE_TYPES.MemberExpression) {
     const methodName = findMemberName(memberExpression);
@@ -180,16 +175,10 @@ function processSelector(
     return false;
   }
 
-  // For AwaitExpression, check if the argument is result-like
-  if (node.type === AST_NODE_TYPES.AwaitExpression) {
-    if (!isResultLike(checker, parserServices, node.argument)) {
-      return false;
-    }
-  } else {
-    // For other node types, check if the node itself is result-like
-    if (!isResultLike(checker, parserServices, node)) {
-      return false;
-    }
+  // Check if the node itself is result-like
+  // For AwaitExpression, this checks the awaited result type (e.g., Result from Promise<Result>)
+  if (!isResultLike(checker, parserServices, node)) {
+    return false;
   }
 
   // Skip CallExpression nodes that are inside AwaitExpression to avoid duplicate reporting


### PR DESCRIPTION
`must-use-result` rule was not detecting `Promise<Result>` when awaited.
This PR fixes the detection logic to check the awaited result type (which is `Result`) instead of the argument type (which is `Promise`).

Relates to #14

- Adjusted `isResultLike` check for `AwaitExpression`
- Removed unnecessary recursion in `isHandledResult`
- Added test cases for `await Promise<Result>`